### PR TITLE
clarify license to LGPL 3.0 or later, add license header to all files (8.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ rather than automata.
   - Damien Pous (initial)
 - Coq-community maintainer(s):
   - Tej Chajed ([**@tchajed**](https://github.com/tchajed))
-- License: [GNU Lesser General Public License v3](LICENSE)
+- License: [GNU Lesser General Public License v3.0 or later](LICENSE)
 - Compatible Coq versions: Coq 8.9 (use the corresponding branch or release for other Coq versions)
 - Compatible OCaml versions: all versions supported by Coq
 - Additional dependencies: none

--- a/meta.yml
+++ b/meta.yml
@@ -29,7 +29,8 @@ maintainers:
   nickname: tchajed
 
 license:
-  fullname: GNU Lesser General Public License v3
+  fullname: GNU Lesser General Public License v3.0 or later
+  identifier: LGPL-3.0-or-later
   shortname: LGPL 3
 
 plugin: true

--- a/src/reify.ml
+++ b/src/reify.ml
@@ -1,3 +1,11 @@
+(**************************************************************************)
+(*  This is part of ATBR, it is distributed under the terms of the        *)
+(*         GNU Lesser General Public License version 3                    *)
+(*              (see file LICENSE for more details)                       *)
+(*                                                                        *)
+(*       Copyright 2009-2010: Thomas Braibant, Damien Pous.               *)
+(**************************************************************************)
+
 open Constr
 open EConstr
 open Names


### PR DESCRIPTION
As per coq-community/manifesto#38, we are trying to be more precise about licenses, and hope to eventually adopt the SPDX format everywhere. This PR for the  v8.9 branch includes the SPDX license identifier as metadata and adds copyright headers to all files.