### PR TITLE
Fixed: counterexample was not displayed when empty word.

### DIFF
--- a/theories/DecideKleeneAlgebra.v
+++ b/theories/DecideKleeneAlgebra.v
@@ -117,7 +117,7 @@ Ltac display_counter_example e ce :=
   let eval_word w :=
     let rec build w :=
       lazymatch w with
-      | nil => fail 1
+      | nil => fail 0
       | ?x::nil => constr:(Reification.unpack (@Reification.val _ e x))
       | ?x::?q => let q := build q in constr:(q * Reification.unpack (@Reification.val _ e x))
       end


### PR DESCRIPTION
This was because "fail 1" was escaping both the lazymatch and the
match, instead of just the lazymatch (alternatively, one can replace
lazymatch with match).

Tested under 8.10.2 and 8.11.0