### PR TITLE
Compatibility with Coq 8.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docs
 *.d
 *.vos
 *.vok
+.lia.cache
 
 # make-related output
 Makefile.coq

--- a/_CoqProject
+++ b/_CoqProject
@@ -2,6 +2,8 @@
 -I src
 
 -arg -w -arg +default
+# FIXME
+-arg -w -arg -deprecated-hint-without-locality,-omega-is-deprecated,-fragile-hint-constr
 -arg -w -arg -variable-collision
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -undo-batch-mode

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,7 +3,7 @@
 
 -arg -w -arg +default
 # FIXME
--arg -w -arg -deprecated-hint-without-locality,-omega-is-deprecated
+-arg -w -arg -deprecated-hint-without-locality
 -arg -w -arg -variable-collision
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -undo-batch-mode

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,7 +3,7 @@
 
 -arg -w -arg +default
 # FIXME
--arg -w -arg -deprecated-hint-without-locality,-omega-is-deprecated,-fragile-hint-constr
+-arg -w -arg -deprecated-hint-without-locality,-omega-is-deprecated
 -arg -w -arg -variable-collision
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -undo-batch-mode

--- a/_CoqProject
+++ b/_CoqProject
@@ -2,8 +2,6 @@
 -I src
 
 -arg -w -arg +default
-# FIXME
--arg -w -arg -deprecated-hint-without-locality
 -arg -w -arg -variable-collision
 -arg -w -arg -projection-no-head-constant
 -arg -w -arg -undo-batch-mode

--- a/theories/BoolView.v
+++ b/theories/BoolView.v
@@ -92,8 +92,8 @@ Instance le_nat_view : Type_View le_lt_bool := { type_view := le_nat_spec }.
 
 Ltac nat_analyse := 
   repeat (
-    try (type_view eq_nat_bool; try subst; try omega_false);
-    try (type_view le_lt_bool; try subst; try omega_false)
+    try (type_view eq_nat_bool; try subst; try lia_false);
+    try (type_view le_lt_bool; try subst; try lia_false)
   ).
 
 
@@ -144,7 +144,7 @@ Proof. intros. nat_analyse; intuition discriminate. Qed.
 Lemma le_lt_bool_true : forall x y, le_lt_bool x y = true <-> x <= y. 
 Proof. intros. nat_analyse; intuition. Qed.
 Lemma le_lt_bool_false : forall x y, le_lt_bool x y = false <-> y < x. 
-Proof. intros. nat_analyse; intuition. Qed.
+Proof. intros. nat_analyse; intuition. lia. Qed.
 
 Hint Rewrite eq_nat_bool_true eq_nat_bool_false le_lt_bool_true le_lt_bool_false : nat_prop.
 Ltac nat_prop := autorewrite with nat_prop in *.

--- a/theories/BoolView.v
+++ b/theories/BoolView.v
@@ -124,6 +124,7 @@ Definition eq_bool_bool := Bool.eqb.
 Lemma eq_bool_spec : forall a b, reflect (a=b) (eq_bool_bool a b).
 Proof.
   intros [|] [|]; simpl; constructor; firstorder.
+  congruence.
 Qed.
 
 Instance eq_bool_view : Type_View eq_bool_bool := { type_view := eq_bool_spec }.
@@ -208,7 +209,7 @@ Proof. intros [|]; firstorder. Qed.
 Lemma negb_false  : forall b, negb b = false <-> b = true. 
 Proof. intros [|]; firstorder. Qed.
 Lemma eq_not_negb  : forall b c, b = c <-> ~ (b = negb c). 
-Proof. intros [|] [|]; firstorder. Qed.
+Proof. intros [|] [|]; firstorder; simpl; try congruence. Qed.
 
 Hint Rewrite andb_false_iff andb_true_iff orb_false_iff orb_true_iff negb_true negb_false : bool_connectors.
 

--- a/theories/Common.v
+++ b/theories/Common.v
@@ -10,8 +10,8 @@
    modules and defines some basic utilities and tactics *)
 
 Require Export Arith.
-Require Export Omega.
-(* Require Export BinNums BinPos PArith.Pnat. *)
+Require Export Lia.
+Require Export BinNums BinPos PArith.Pnat.
 Require Export Coq.Program.Equality. 
 Require Export Setoid Morphisms. 
 
@@ -27,8 +27,8 @@ Notation "f >> g" := (comp f g) (at level 50).
    an hypothesis [H] by generating the corresponding subgoals) *)
 Definition apply X x Y (f: X -> Y) := f x.
 
-(** Tactics to resolve a goal by using a contradiction in the hypotheses, using either [omega] or [tauto] *)
-Ltac omega_false := exfalso; omega.
+(** Tactics to resolve a goal by using a contradiction in the hypotheses, using either [lia] or [tauto] *)
+Ltac lia_false := exfalso; lia.
 Ltac tauto_false := exfalso; tauto.
 
 (** This destructor sometimes works better that the standard [destruct] *)
@@ -54,17 +54,17 @@ Ltac ti_auto := eauto with typeclass_instances.
    - <simpl> is a rewriting database, to be used with the [rsimpl] tactic. It contains lemmas like [1*x == x] 
    [0# == 1] and provides a simple way to normalise the goal "in depth", using the setoid infrastructure.
    This is not really efficient, however.
-   - <omega> contains hints to use [omega] when proof search failed ; this basically allows us to avoid 
-   using [omega] in trivial cases.
+   - <lia> contains hints to use [lia] when proof search failed ; this basically allows us to avoid 
+   using [lia] in trivial cases.
 *)
 Create HintDb compat discriminated.
 Create HintDb algebra discriminated.
 
 Ltac rsimpl := simpl; autorewrite with simpl using ti_auto.
 
-Hint Extern 9 (@eq nat ?x ?y) => instantiate; abstract omega: omega.
-Hint Extern 9 (Peano.le ?x ?y) => instantiate; abstract omega: omega.
-Hint Extern 9 (Peano.lt ?x ?y) => instantiate; abstract omega: omega.
+Hint Extern 9 (@eq nat ?x ?y) => instantiate; abstract lia: lia.
+Hint Extern 9 (Peano.le ?x ?y) => instantiate; abstract lia: lia.
+Hint Extern 9 (Peano.lt ?x ?y) => instantiate; abstract lia: lia.
 
 (** Tactic to use when apply does not smartly unify *)
 Ltac rapply H := first 

--- a/theories/Common.v
+++ b/theories/Common.v
@@ -11,6 +11,7 @@
 
 Require Export Arith.
 Require Export Omega.
+(* Require Export BinNums BinPos PArith.Pnat. *)
 Require Export Coq.Program.Equality. 
 Require Export Setoid Morphisms. 
 

--- a/theories/Common.v
+++ b/theories/Common.v
@@ -62,9 +62,9 @@ Create HintDb algebra discriminated.
 
 Ltac rsimpl := simpl; autorewrite with simpl using ti_auto.
 
-Hint Extern 9 (@eq nat ?x ?y) => instantiate; abstract lia: lia.
-Hint Extern 9 (Peano.le ?x ?y) => instantiate; abstract lia: lia.
-Hint Extern 9 (Peano.lt ?x ?y) => instantiate; abstract lia: lia.
+Global Hint Extern 9 (@eq nat ?x ?y) => instantiate; abstract lia: lia.
+Global Hint Extern 9 (Peano.le ?x ?y) => instantiate; abstract lia: lia.
+Global Hint Extern 9 (Peano.lt ?x ?y) => instantiate; abstract lia: lia.
 
 (** Tactic to use when apply does not smartly unify *)
 Ltac rapply H := first 

--- a/theories/DKA_Construction.v
+++ b/theories/DKA_Construction.v
@@ -157,7 +157,7 @@ Module Algebraic.
   Lemma belong_incr: forall A s, belong s A -> belong s (incr A).
   Proof. intros. destruct A. simpl in *. auto with arith. Qed.
   Lemma belong_incr': forall A, belong (size A) (incr A).
-  Proof. intros. simpl. omega. Qed.
+  Proof. intros. simpl. lia. Qed.
   Lemma belong_add: forall i j b A s, belong s A -> belong s (add i j b A).
   Proof. intros. destruct A. assumption. Qed.
   Lemma belong_add_one: forall i j A s, belong s A -> belong s (add_one i j A).
@@ -427,9 +427,9 @@ Module Correctness.
   Transparent zero one plus dot star.
 
   Lemma belong_incr: forall A s, belong s A -> belong s (incr A).
-  Proof. intros. destruct A; simpl in *. num_omega. Qed.
+  Proof. intros. destruct A; simpl in *. num_lia. Qed.
   Lemma belong_incr': forall A, belong (size A) (incr A).
-  Proof. intros. destruct A. simpl. num_omega. Qed.
+  Proof. intros. destruct A. simpl. num_lia. Qed.
   Lemma belong_add_one: forall i j A s, belong s A -> belong s (add_one i j A).
   Proof. intros. destruct A. assumption. Qed.
   Lemma belong_add_var: forall i j n A s, belong s A -> belong s (add_var i j n A).
@@ -552,7 +552,7 @@ Module Correctness.
     
     case (epsilonbrel (mk sA epsA deltaA mlA) (state_of_nat s) (state_of_nat t)); simpl; 
       nat_analyse; simpl; fold_regex; auto with algebra;
-      num_analyse; simpl; fold_regex; auto with algebra; num_omega_false.
+      num_analyse; simpl; fold_regex; auto with algebra; num_lia_false.
     Transparent add_one.
   Qed.
 
@@ -576,7 +576,7 @@ Module Correctness.
      reflexivity.
      rewrite IHle. rewrite labelling_S.
      case_eq (deltabrel A i (num_of_nat m) j); intro Hij.
-      apply HA in Hij. num_omega_false. 
+      apply HA in Hij. num_lia_false. 
       unfold xif. semiring_reflexivity.
   Qed.
 
@@ -595,7 +595,7 @@ Module Correctness.
      rewrite 2 labelling_S. rewrite IHn. clear IHn.
      rewrite deltabrel_add_var. bool_simpl.
      unfold labelling; simpl. 
-     num_analyse; try num_omega_false; subst; simpl; bool_simpl; simpl; fold_regex; try semiring_reflexivity.
+     num_analyse; try num_lia_false; subst; simpl; bool_simpl; simpl; fold_regex; try semiring_reflexivity.
      case (deltabrel A i (num_of_nat n) j); simpl; fold_regex; semiring_reflexivity.
   Qed.
 
@@ -629,15 +629,15 @@ Opaque equal.
     Algebraic.incr (preNFA_to_preMAUT A) [=0=] preNFA_to_preMAUT (incr A).
   Proof.
     intros [s ? ? ?] HA. unfold incr, preNFA_to_preMAUT. simpl.  
-    replace (nat_of_num(S s)) with (nat_of_state  s +1)%nat by (clear;num_omega).
+    replace (nat_of_num(S s)) with (nat_of_state  s +1)%nat by (clear;num_lia).
     constructor. mx_intros i j Hi Hj. simpl. 
     destruct_blocks; trivial; fold_regex;
       (case_eq (epsilonbrel (mk (S s) epsilonmap0 deltamap0 max_label0) (state_of_nat i) (state_of_nat j)); 
-        intro Hij; [apply HA in Hij; cbn in *; exfalso; num_omega | 
+        intro Hij; [apply HA in Hij; cbn in *; exfalso; num_lia | 
           symmetry; rewrite labelling_empty; 
             [ auto with algebra | 
               intros a; apply not_true_eq_false; intro F; 
-                apply HA in F; simpl in *; exfalso; num_omega ]]).
+                apply HA in F; simpl in *; exfalso; num_lia ]]).
   Qed.
 Transparent equal.
 
@@ -730,19 +730,19 @@ Transparent equal.
   Proof.
     intros A s H HA Hs.
     apply epsilon_rt_incr, rt_t in H as [->|H].
-     num_omega.
+     num_lia.
      apply trans_tn1 in H. inversion_clear H.
-     apply HA in H0. num_omega.
-     apply HA in H0. num_omega.
+     apply HA in H0. num_lia.
+     apply HA in H0. num_lia.
   Qed.
   Lemma not_epsilon_rt_incr_right: forall A s, epsilon_rt (incr A) (size A) s -> bounded A -> belong s A -> False.
   Proof.
     intros A s H HA Hs.
     apply epsilon_rt_incr, rt_t in H as [<-|H].
-     num_omega.
+     num_lia.
      apply trans_t1n in H. inversion_clear H.
-     apply HA in H0. num_omega.
-     apply HA in H0. num_omega.
+     apply HA in H0. num_lia.
+     apply HA in H0. num_lia.
   Qed.
   Ltac not_epsilon := 
     match goal with 
@@ -966,7 +966,7 @@ Lemma inf_leq: forall n m, (forall k, k<n -> k<m) -> n <= m.
 Proof. intros [|n] m H. trivial with arith. elim (H n); auto. Qed.
 
 Lemma le_antisym: forall n m: num, n <= m -> m <= n -> n = m.
-Proof. intros. num_omega. Qed. 
+Proof. intros. num_lia. Qed. 
 
 Lemma max_label_X_to_eNFA a: eNFA.max_label (X_to_eNFA a) = max_label (build a 0 1 empty).
 Proof. unfold X_to_eNFA. destruct (build a 0 1 empty). reflexivity. Qed.
@@ -984,5 +984,5 @@ Proof.
    rewrite H in Hd. eapply collect_max_label in Hd as [Hd|?].
     eapply le_lt_trans. eassumption. unfold statesetelt_of_nat in Hd. rewrite id_nat in Hd. eassumption.
     NumSetProps.setdec.
-    simpl in *. compute in H0. omega_false.
+    simpl in *. compute in H0. lia_false.
 Qed.

--- a/theories/DKA_DFA_Equiv.v
+++ b/theories/DKA_DFA_Equiv.v
@@ -313,10 +313,10 @@ Section correctness.
   Proof.
     intros tar Hwf ml; revert tar Hwf.
     induction ml; intros.
-     omega_false.
+     lia_false.
      simpl.
       destruct (eq_nat_dec a ml). subst. apply complete_incr. apply in_union.
-      apply IHml; ti_auto. omega.
+      apply IHml; ti_auto. lia.
   Qed.
 
 
@@ -361,7 +361,7 @@ Section correctness.
     invariant t -> below x size -> below y size -> loop A n w t x y = inl t' ->  
     correct_ind t t' x y /\ invariant t'.
   Proof.
-    induction n. intros. omega_false.
+    induction n. intros. lia_false.
     intros w tarjan tar' x y Hsize Hstat Hx Hy. simpl loop.
     rewrite DS.test_and_unify_eq.
     case_eq (DS.equiv tarjan x y). intros [|] u Hn; simpl. 
@@ -399,7 +399,7 @@ Section correctness.
     clear IHn. intro Hr.
     destruct (IH _ Hr) as [IH1 IH2]; clear Hr IH. 
      apply in_union. 
-     apply (measure_union_strict (size:=size)) in Hn; auto; num_omega. 
+     apply (measure_union_strict (size:=size)) in Hn; auto; num_lia. 
      apply invariant_prog; assumption.
     split; auto. constructor. 
      intros l Hl. simpl; simpl in Hl. 
@@ -407,7 +407,7 @@ Section correctness.
 
      transitivity (DS.union tarjan x y). apply DSUtils.le_union. apply IH1.
      apply le_trans with (measure (DS.union tarjan x y)). 
-     apply IH1. apply (measure_union_strict (size:=size)) in Hn; auto using lt_le_weak; num_omega.
+     apply IH1. apply (measure_union_strict (size:=size)) in Hn; auto using lt_le_weak; num_lia.
      apply IH1. apply in_union.
   Qed.
 
@@ -506,8 +506,8 @@ Section correctness.
       apply xif_compat; auto.
       rewrite 2 id_num. apply <- bool_prop_iff. rewrite 2 T_true. 
       destruct tarjan_correct as [[ _ _ _ H] _]. rewrite H. tauto.  
-      num_omega.
-      num_omega.
+      num_lia.
+      num_lia.
        
       (* y * m <== m * y *)
       mx_intros i k Hi Hk. simpl; fold_regex.
@@ -517,12 +517,12 @@ Section correctness.
        setoid_rewrite sum_distr_left. rewrite sum_inversion. (* BUG setoid_rewrite/rewrite: très long... *)
        apply sum_incr; intros a Ha. simpl; fold_regex. fold_leq.
        xif_destruct; unfold xif at 1; trivial with algebra.
-       leq_sum (delta a i). pose proof (bounded_delta Hbounds a i). num_omega.
+       leq_sum (delta a i). pose proof (bounded_delta Hbounds a i). num_lia.
        bool_simpl. num_prop. rewrite H0.
        rewrite (simulation H); trivial. 
         unfold xif. semiring_reflexivity.
-        num_omega. 
-        num_omega. 
+        num_lia. 
+        num_lia. 
             
       (* y * v == v *)
       mx_intros i j Hi Hj. clear - Hi Hbounds i' Hi' Hj' _H. simpl; fold_regex.
@@ -598,7 +598,7 @@ Section completeness.
         case loop. 
          intros tar' _ H. apply IHa in H; auto with arith. 
          intros p H H'. dependent destruction H'. apply H; auto.
-          intros c [->|Hc]; auto with arith. num_omega. 
+          intros c [->|Hc]; auto with arith. num_lia. 
 
        clear IHn. intro H'; injection H'; intros; subst; clear H'.
        StateSetProps.mem_analyse; StateSetProps.mem_analyse; 

--- a/theories/DKA_DFA_Equiv.v
+++ b/theories/DKA_DFA_Equiv.v
@@ -77,7 +77,7 @@ Qed.
 
 Section comb.
 
-  Local Hint Resolve @DS.union_WF @DS.empty_WF: typeclass_instances.
+  Local Hint Resolve DS.union_WF DS.empty_WF: typeclass_instances.
 
   Inductive combine_no_length X Y : list X -> list Y -> Type :=
   |cnl_nil : combine_no_length nil nil
@@ -164,7 +164,7 @@ Section correctness.
 
   Definition prog (t t' : DS.T) := forall R, diag {{t}} {{t +++ R}} -> diag {{t'}} {{t' +++ R}}.
 
-  Local Hint Resolve @DS.union_WF @DS.empty_WF: typeclass_instances.
+  Local Hint Resolve DS.union_WF DS.empty_WF: typeclass_instances.
   Existing Instance complete_WF.
   
   Instance preorder_prog : PreOrder prog.

--- a/theories/DKA_DFA_Language.v
+++ b/theories/DKA_DFA_Language.v
@@ -97,13 +97,14 @@ Transparent dot plus star one zero.
 Lemma lang_sum: forall (f: nat -> language) w n i, sum i n f w <-> exists2 j, j<n & f (i+j)%nat w.
 Proof.
   induction n. 
-   compute. firstorder.
-   intros j. simpl. unfold lang_union. rewrite IHn. clear IHn. intuition. 
-   exists O; auto with arith. rewrite plus_comm. assumption.
-   destruct H0 as [k ? ?]. exists (Datatypes.S k); auto with arith. rewrite <- plus_n_Sm. assumption.
-   destruct H as [[|k] ? ?].
-    left. rewrite plus_comm in H0. assumption.
-    right. exists k; auto with arith. rewrite <- plus_n_Sm in H0. assumption.
+  - compute. firstorder.
+    omega.
+  - intros j. simpl. unfold lang_union. rewrite IHn. clear IHn. intuition. 
+    exists O; auto with arith. rewrite plus_comm. assumption.
+    destruct H0 as [k ? ?]. exists (Datatypes.S k); auto with arith. rewrite <- plus_n_Sm. assumption.
+    destruct H as [[|k] ? ?].
+    + left. rewrite plus_comm in H0. assumption.
+    + right. exists k; auto with arith. rewrite <- plus_n_Sm in H0. assumption.
 Qed.   
 
 Lemma mx_leq_pointwise `{SL: SemiLattice}: forall n m A (M N: MX_ A n m), 

--- a/theories/DKA_DFA_Language.v
+++ b/theories/DKA_DFA_Language.v
@@ -98,7 +98,7 @@ Lemma lang_sum: forall (f: nat -> language) w n i, sum i n f w <-> exists2 j, j<
 Proof.
   induction n. 
   - compute. firstorder.
-    omega.
+    lia.
   - intros j. simpl. unfold lang_union. rewrite IHn. clear IHn. intuition. 
     exists O; auto with arith. rewrite plus_comm. assumption.
     destruct H0 as [k ? ?]. exists (Datatypes.S k); auto with arith. rewrite <- plus_n_Sm. assumption.
@@ -212,7 +212,7 @@ Proof.
   setoid_rewrite xif_xif_and. 
   rewrite sum_inversion.
   rewrite (sum_collapse (G:=@lang_Graph label) (n:=DFA.initial A)).
-   2: apply DFA.bounded_initial in HA; num_omega.
+   2: apply DFA.bounded_initial in HA; num_lia.
    2: simpl; intros; fold_langAlg label. 
    2: apply sum_zero; intros; apply xif_false.
    2: bool_connectors; nat_prop; intuition. 
@@ -224,7 +224,7 @@ Proof.
    match goal with |- context[box ?n ?m ?f] => set (M:=box n m f) end.
    apply leq_antisym.
     apply sum_leq. simpl. fold_langAlg label. intros n _ Hn.
-    rewrite (@mx_star_charac _ M s n); auto. 2: num_omega. simpl.
+    rewrite (@mx_star_charac _ M s n); auto. 2: num_lia. simpl.
     bool_simpl. StateSetProps.mem_analyse; simpl. 2: fold_langAlg label; auto with algebra.
     rewrite lang_Union_spec. intro m. revert s Hs.
     induction m; intros s Hs.
@@ -244,8 +244,8 @@ Proof.
       setoid_rewrite lang_leq in IHm. split. 
        eapply IHm; auto. apply (DFA.bounded_delta HA).
        intros b [<-|Hb]. num_simpl. assumption. eapply (IHm (DFA.delta A a s)); eauto. apply (DFA.bounded_delta HA). 
-      specialize (DFA.bounded_delta HA a s). num_omega. 
-      intros. simpl in H. num_analyse. elim H. rewrite <- e. num_omega.
+      specialize (DFA.bounded_delta HA a s). num_lia. 
+      intros. simpl in H. num_analyse. elim H. rewrite <- e. num_lia.
       reflexivity.
 
     rewrite lang_leq. 
@@ -253,20 +253,20 @@ Proof.
        exists2 j, StateSet.In j (DFA.finaux A) & !((M:LMX _ _) #) s (nat_of_state j) w).
      intro C. intros w [Hw Hw']. destruct (C _ Hw Hw') as [j Hj Hj']. 
      rewrite lang_sum. exists (nat_of_state j).
-      apply HA in Hj. num_omega. simpl. bool_simpl. rewrite (StateSet.mem_1 Hj). assumption.
+      apply HA in Hj. num_lia. simpl. bool_simpl. rewrite (StateSet.mem_1 Hj). assumption.
      intro w. revert s Hs. induction w; simpl; intros s Hs Hw Hw'.
-      assert (Hs': (s < DFA.size A)%nat). num_omega. 
+      assert (Hs': (s < DFA.size A)%nat). num_lia. 
       exists s; auto. 
       rewrite (@mx_star_charac _ M s s Hs' Hs' nil). exists O. simpl. bool_simpl. reflexivity.
       
       apply IHw in Hw; try apply (DFA.bounded_delta HA). clear IHw. destruct Hw as [j Hj' Hj].
       exists j; auto. 
       rewrite (fun Hs Hj => @mx_star_charac _ M s (nat_of_state j) Hs Hj (a::w)).
-       2: num_omega. 2: apply HA in Hj'; num_omega.
+       2: num_lia. 2: apply HA in Hj'; num_lia.
       rewrite (fun Hs Hj => @mx_star_charac _ M (DFA.delta A a s) (nat_of_state j) Hs Hj w) in Hj.
-       2: specialize (DFA.bounded_delta HA a s); num_omega. 2: apply HA in Hj'; num_omega.
+       2: specialize (DFA.bounded_delta HA a s); num_lia. 2: apply HA in Hj'; num_lia.
       destruct Hj as [n Hn]. exists (Datatypes.S n). simpl. fold_langAlg label.
-      rewrite lang_sum. exists (DFA.delta A a s). specialize (DFA.bounded_delta HA a s). num_omega.
+      rewrite lang_sum. exists (DFA.delta A a s). specialize (DFA.bounded_delta HA a s). num_lia.
       simpl Peano.plus. exists (a::nil).
       rewrite 2id_num.
       rewrite lang_sum. simpl. exists a.

--- a/theories/DKA_Determinisation.v
+++ b/theories/DKA_Determinisation.v
@@ -144,13 +144,14 @@ Section S.
   Proof.
     unfold build_store.
     pose (Heq:=powerfix_linearfix (A:=Store) (B:=stateset -> num -> Store) (R:=pointwise_relation _ (pointwise_relation _ (@eq _)))).
-    unfold pointwise_relation at -1 -2 -3 in Heq.
     rewrite Heq. 
     generalize (state_of_nat 0) initiaux initial_store. generalize (power size) as n. 
     induction n; intros s p np; simpl.
      reflexivity.
      apply fold_num_compat, step_compat. repeat intro. apply IHn.
-     intros f g H s ? <- p np. apply fold_num_compat, step_compat, H.  
+     intros f g H s ? <- p np. apply fold_num_compat, step_compat.  
+     unfold pointwise_relation; simpl.
+     apply H.
   Qed.
 
 

--- a/theories/DKA_Determinisation.v
+++ b/theories/DKA_Determinisation.v
@@ -232,7 +232,7 @@ Section S.
     forall P, defined s (fun n a => P n a \/ n=np) -> defined (steps i s p np) P.
   Proof. 
     induction i; intros s p np Hsize H Hp; simpl.
-     omega_false.
+     lia_false.
      cut (forall a: num, extends s (fold_labels (step' (steps i) p np) a s) /\
        forall P, defined s (fun n b => P n b \/ n = np /\ b < a) ->
          defined (fold_labels (step' (steps i) p np) a s) P).
@@ -242,7 +242,7 @@ Section S.
      intro a. revert s Hsize H Hp. induction a using num_peano_rec; intros [[t d] n] Hsize H Hp.
       rewrite fold_num_O. split.
        apply reflexive_extends. assumption.
-       intros P HP m b Hm Hb. specialize (HP m b Hm Hb). intuition auto. num_omega_false.
+       intros P HP m b Hm Hb. specialize (HP m b Hm Hb). intuition auto. num_lia_false.
       rewrite fold_num_S. simpl. StateSetMapProps.find_analyse.
        (* existing state *)
        assert (H': invariant (t, StateLabelMap.add (np, a) x d, n)).
@@ -256,7 +256,7 @@ Section S.
         constructor; auto with map. reflexivity.
         intros P HP. eapply IHa; simpl; auto with map. 
         intros m' b Hm Hb. specialize (HP _ b Hm Hb). simpl in *.
-        intuition subst; auto with map. destruct (eq_spec a b). subst. auto with map. num_omega. 
+        intuition subst; auto with map. destruct (eq_spec a b). subst. auto with map. num_lia. 
 
        (* new state *)
        set (s' := (StateSetMap.add (delta_set a p) n t, StateLabelMap.add (np: NumOTA.t, a) n d, S n)).
@@ -264,20 +264,20 @@ Section S.
          constructor; simpl.
           intros q nq. StateSetMapProps.map_iff. intuition subst.
            intros x Hx. rewrite <- H1 in Hx. eapply bounded_delta_set, Hx.  
-           num_omega.
+           num_lia.
            apply (i_table_wf H H3).
-           specialize (i_table_wf H H3). simpl. num_omega.
+           specialize (i_table_wf H H3). simpl. num_lia.
           intros q q' nq. StateSetMapProps.map_iff. intuition subst. 
            StateSetProps.setdec.
-           exfalso. specialize (i_table_wf H H5). simpl. num_omega.
-           exfalso. specialize (i_table_wf H H4). simpl. num_omega.
+           exfalso. specialize (i_table_wf H H5). simpl. num_lia.
+           exfalso. specialize (i_table_wf H H4). simpl. num_lia.
            apply (i_table_inj H H4 H5).
           intros m Hm. destruct (eq_num_dec m n). subst.
            eauto with map.
-           destruct (@i_table_surj _ H m) as [q ?]. simpl. num_omega. exists q.
+           destruct (@i_table_surj _ H m) as [q ?]. simpl. num_lia. exists q.
             apply StateSetMap.add_2; trivial. intro F. rewrite <- F in H1. elim H0. exists m; assumption.
           erewrite StateSetMapProps.cardinal_2; eauto. 
-           apply i_table_size in H. simpl in H. rewrite H. num_omega.
+           apply i_table_size in H. simpl in H. rewrite H. num_lia.
            intro; reflexivity.
           intros nq b nq'. StateLabelMapProps.map_iff. intuition subst.
            apply StateLabel.P.reflect in H1. injection H1; intros; subst; clear H1.
@@ -290,11 +290,11 @@ Section S.
        specialize (IHi s' (delta_set a p) n). 
        simpl in IHi. destruct IHi as [IHi1 IHi2]; auto with map.
         clear - Hsize H Hp H0 H'. subst s'. simpl in *.
-        apply store_size_bound in H'. simpl in *. pose proof (power_positive size). num_omega.
+        apply store_size_bound in H'. simpl in *. pose proof (power_positive size). num_lia.
 
        specialize (IHa (steps i s' (delta_set a p) n)). 
        simpl in IHa. destruct IHa as [IHa1 IHa2].
-        clear IHi2. subst s'. apply e_next in IHi1. simpl in *. num_omega.
+        clear IHi2. subst s'. apply e_next in IHi1. simpl in *. num_lia.
         apply IHi1.
         apply IHi1. simpl.
          apply StateSetMap.add_2; trivial. intro F. rewrite F in H0. elim H0. exists np. assumption.
@@ -305,14 +305,14 @@ Section S.
         constructor; simpl; auto.  
          intros q nq Hq. 
           apply StateSetMap.add_2; trivial. intro F. rewrite <- F in Hq. elim H0. exists nq. assumption.
-         num_omega.
+         num_lia.
 
         intros P HP. apply IHa2. apply IHi2. unfold s' in *. clear - Hp HP. 
         intros m b Hm Hb. simpl in *.
         destruct (eq_num_dec m n). subst. auto.
-        destruct (HP m b) as [[y ?]|[ ?|[? ?]]]; subst; simpl in *; auto with map. num_omega. 
+        destruct (HP m b) as [[y ?]|[ ?|[? ?]]]; subst; simpl in *; auto with map. num_lia. 
          clear - H. eauto with map.
-         destruct (eq_spec a b). subst. auto with map. num_omega. 
+         destruct (eq_spec a b). subst. auto with map. num_lia. 
   Qed. 
 
   (** the initial store satisfies the invariant *)
@@ -323,7 +323,7 @@ Section S.
       intros x Hx. rewrite <- H in Hx. apply (NFA.bounded_initiaux HA Hx).
      StateSetMapProps.find_tac; StateSetProps.setdec.
      exists initiaux. replace i with (state_of_nat O). auto with map. 
-      change 2%positive with (state_of_nat 1) in H. num_omega.
+      change 2%positive with (state_of_nat 1) in H. num_lia.
      reflexivity.
      revert H. StateLabelMapProps.map_iff. tauto. 
   Qed.
@@ -335,12 +335,12 @@ Section S.
   Proof.
     rewrite build_store_spec.
     destruct (@steps_correct (power size) initial_store initiaux 0) as [H H'].
-     simpl. pose proof (power_positive size). change 2%positive with (state_of_nat 1). num_omega. 
+     simpl. pose proof (power_positive size). change 2%positive with (state_of_nat 1). num_lia. 
      apply invariant_initial_store.
      simpl. auto with map.
     split. apply H.
     intros n a Hn Ha. destruct (fun H => H' (fun _ _ => False) H n a Hn Ha); try tauto.
-    intros m b Hm _. simpl in Hm. right. right. change 2%positive with (state_of_nat 1) in Hm. num_omega. 
+    intros m b Hm _. simpl in Hm. right. right. change 2%positive with (state_of_nat 1) in Hm. num_lia. 
   Qed.
 
   (** in particular, the constructed store satisfies the invariant *)
@@ -483,7 +483,7 @@ Section S.
   Lemma positive_size: 0 < size'.
   Proof.
     assert (H:=build_store_correct). eapply proj1, e_next in H. simpl in H.
-    change 2%positive with (state_of_nat 1) in H. num_omega.
+    change 2%positive with (state_of_nat 1) in H. num_lia.
   Qed.
 
   (** its transitions are bounded *)
@@ -528,7 +528,7 @@ Section S.
 
     (** u *)
     Opaque dot one zero equal. simpl. Transparent dot one zero equal.
-    rewrite mx_point_one_left by num_omega. 
+    rewrite mx_point_one_left by num_lia. 
     mx_intros i j Hi Hj. Opaque eq_nat_bool. simpl. bool_simpl. simpl. fold_regex. Transparent eq_nat_bool. 
     rewrite theta_0. reflexivity. 
 
@@ -542,16 +542,16 @@ Section S.
     setoid_rewrite dot_neutral_left.
     setoid_rewrite dot_neutral_right.
     apply leq_antisym; apply compare_sum_xif_zero; intros u Hu; bool_connectors; intros [Hu' Hu'']; simpl in *.
-     exists (nat_of_state (delta' d a i)); auto. specialize (Hdelta'_below a i). num_omega. 
+     exists (nat_of_state (delta' d a i)); auto. specialize (Hdelta'_below a i). num_lia. 
      bool_connectors. num_prop. rewrite id_num. split; trivial.
-     rewrite Htheta_delta' by num_omega.
+     rewrite Htheta_delta' by num_lia.
      StateSetProps.mem_prop. apply <- in_delta_set. exists (state_of_nat u); auto.
 
      num_prop. rewrite Hu' in Hu''. clear u Hu Hu'. simpl in Hi. 
-     rewrite Htheta_delta', <- StateSetProps.mem_iff in Hu'' by num_omega.
+     rewrite Htheta_delta', <- StateSetProps.mem_iff in Hu'' by num_lia.
      apply -> in_delta_set in Hu''. destruct Hu'' as [k [? ?]].
      exists (nat_of_state k). 
-      apply Htheta_below, proj2 in H. clear - H. num_omega.
+      apply Htheta_below, proj2 in H. clear - H. num_lia.
       rewrite id_num. bool_connectors. StateSetProps.mem_prop. rewrite id_num. auto. 
 
     (** v *)
@@ -563,7 +563,7 @@ Section S.
 
      rewrite <- StateSetProps.exists_iff in H by trivial. destruct H as [u [Hu Hu']].
      rewrite (sum_fixed_xif_zero (v:=nat_of_state u)). auto with algebra. 
-      StateSetProps.mem_prop. apply HA in Hu'. apply Htheta_below, proj2 in Hu. num_omega.
+      StateSetProps.mem_prop. apply HA in Hu'. apply Htheta_below, proj2 in Hu. num_lia.
      rewrite id_num. bool_connectors. StateSetProps.mem_prop. auto.  
 
      apply sum_zero. intros m Hm. apply xif_false. simpl.

--- a/theories/DKA_Epsilon.v
+++ b/theories/DKA_Epsilon.v
@@ -255,7 +255,7 @@ Proof.
    intros i Hi. destruct (eq_num_dec i size).
     subst. auto. 
     apply IHin. destruct Hi as [Hi|Hi]; auto.
-    left. clear -Hi n. num_omega.
+    left. clear -Hi n. num_lia.
 Qed.
 
 
@@ -316,27 +316,27 @@ Proof.
    apply algebraic_rt_closure; mx_intros i j Hi Hj; simpl; fold_regex; fold_leq. 
     nat_analyse; fold_regex; auto with algebra.
     subst. type_view StateSet.mem; auto with algebra. 
-    elim n. rewrite <- rt_closure_spec by num_omega. constructor 1.
+    elim n. rewrite <- rt_closure_spec by num_lia. constructor 1.
 
     apply sum_leq. intros k _ Hk.
     type_view StateSet.mem. 2: simpl; fold_regex; semiring_reflexivity.
     type_view StateSet.mem. 2: simpl; fold_regex; semiring_reflexivity.
     type_view StateSet.mem. simpl; fold_regex; semiring_reflexivity.
     elim n.
-     rewrite <- rt_closure_spec by num_omega. 
+     rewrite <- rt_closure_spec by num_lia. 
      apply trans_rt1n. constructor 3 with (sn k); 
-      apply rt1n_trans; apply <- rt_closure_spec; eauto; unfold below; num_omega.
+      apply rt1n_trans; apply <- rt_closure_spec; eauto; unfold below; num_lia.
      
     type_view StateSet.mem. 2: simpl; fold_regex; semiring_reflexivity.
     type_view StateSet.mem. simpl; fold_regex; semiring_reflexivity.
     elim n.
-     rewrite <- rt_closure_spec by num_omega.
+     rewrite <- rt_closure_spec by num_lia.
      constructor 2 with (sn j). apply StateSet.mem_1 in i0. assumption. constructor 1.
 
    mx_intros i j Hi Hj. simpl. fold_regex; fold_leq.
    set (m := mx_bool Datatypes.tt (ns size) (ns size) (fun i j => StateSet.mem (sn j) (f (sn i)))).
    type_view StateSet.mem; auto with algebra. rename i0 into Hij.
-   rewrite <- rt_closure_spec in Hij by num_omega.
+   rewrite <- rt_closure_spec in Hij by num_lia.
    revert Hi Hj. rewrite <- (id_nat i), <- (id_nat j). revert Hij.  
    generalize (sn j) as j'. generalize (sn i) as i'. clear - Hbounded.
    intros i j ij. induction ij; intros Hi Hj.
@@ -449,7 +449,7 @@ Proof.
 
   (* v' = v *)
   mx_intros i j Hi Hj. simpl. fold_regex. apply xif_compat; trivial.
-  bool_simpl. rewrite bool_prop_iff. num_prop. nat_prop. num_omega. 
+  bool_simpl. rewrite bool_prop_iff. num_prop. nat_prop. num_lia. 
 Qed. 
 
 

--- a/theories/DKA_Merge.v
+++ b/theories/DKA_Merge.v
@@ -89,7 +89,7 @@ Lemma sum_collapse': forall k f b (j: state), (j<k)%nat ->
 Proof.
   intros. rewrite (sum_collapse (n:=j)); auto.
    cbn. rewrite id_num. bool_simpl. reflexivity.
-   intros. num_analyse. num_omega. reflexivity.
+   intros. num_analyse. num_lia. reflexivity.
 Qed.
 
 Lemma and_neutral_left: forall (A B: Prop), A -> (A/\B <-> B). Proof. tauto. Qed.
@@ -110,10 +110,10 @@ Proof.
 
    mx_intros i j Hi Hj. Transparent dot. simpl. fold_regex. Opaque dot. 
    apply bounded_initial in HA. 
-   setoid_rewrite xif_dot. rewrite (sum_collapse (n:=initial A)). 2: num_omega. 
+   setoid_rewrite xif_dot. rewrite (sum_collapse (n:=initial A)). 2: num_lia. 
     bool_simpl. simpl. rewrite dot_neutral_left. apply xif_compat; auto. 
     rewrite id_num. rewrite bool_prop_iff. bool_connectors. num_prop. nat_prop.
-    intuition; num_omega.
+    intuition; num_lia.
     simpl. intros x Hx. nat_analyse; simpl; auto with algebra.
 
    mx_intros i j Hi Hj. Transparent dot. simpl. fold_regex. Opaque dot. 
@@ -125,15 +125,15 @@ Proof.
     setoid_rewrite dot_xif_zero. setoid_rewrite dot_neutral_right. setoid_rewrite xif_xif_and.
     rewrite sum_collapse'. setoid_rewrite <- andb_assoc. rewrite sum_collapse'.  
       apply xif_compat; auto. rewrite 2id_num. rewrite match_pi0. 
-      rewrite bool_prop_iff. bool_connectors. num_prop. intuition. num_omega. apply (bounded_delta HA).
-      unfold s. rewrite <- lt_nat_spec. apply below_max_pi0. num_omega.
+      rewrite bool_prop_iff. bool_connectors. num_prop. intuition. num_lia. apply (bounded_delta HA).
+      unfold s. rewrite <- lt_nat_spec. apply below_max_pi0. num_lia.
       apply -> lt_nat_spec. apply (bounded_delta HA).
 
    mx_intros i j Hi Hj. Transparent dot. simpl. fold_regex. Opaque dot. 
     setoid_rewrite dot_xif_zero. setoid_rewrite dot_neutral_left.
     setoid_rewrite <- andb_assoc. rewrite sum_collapse'. apply xif_compat; auto.
     rewrite id_num. rewrite bool_prop_iff. bool_connectors. num_prop. StateSetProps.mem_prop.
-    rewrite and_neutral_left by num_omega.
+    rewrite and_neutral_left by num_lia.
     (* BUG d'induction *)
     (* induction (finaux A) using StateSetProps.set_induction_above. *)
     generalize (finaux A). rapply StateSetProps.set_induction_above.
@@ -149,7 +149,7 @@ Proof.
      rewrite StateSetProps.fold_add_above; ti_auto.
      StateSetProps.set_iff. rewrite <- IHx. intuition (try subst; auto using pi0_inj). 
      repeat intro. psubst. rewrite H3. reflexivity.
-    apply -> lt_nat_spec. apply below_max_pi0. num_omega. 
+    apply -> lt_nat_spec. apply below_max_pi0. num_lia. 
     Opaque NumSet.add.
   Qed.
 
@@ -165,10 +165,10 @@ Proof.
   
    mx_intros i j Hi Hj. Transparent dot. simpl. fold_regex. Opaque dot. 
    apply bounded_initial in HB. 
-   setoid_rewrite xif_dot. rewrite (sum_collapse (n:=initial B)). 2: num_omega. 
+   setoid_rewrite xif_dot. rewrite (sum_collapse (n:=initial B)). 2: num_lia. 
     bool_simpl. simpl. rewrite dot_neutral_left. apply xif_compat; auto. 
     rewrite id_num. rewrite bool_prop_iff. bool_connectors. num_prop. nat_prop.
-    intuition; num_omega.
+    intuition; num_lia.
     simpl. intros x Hx. nat_analyse; simpl; auto with algebra.
 
    mx_intros i j Hi Hj. Transparent dot. simpl. fold_regex. Opaque dot. 
@@ -180,15 +180,15 @@ Proof.
     setoid_rewrite dot_xif_zero. setoid_rewrite dot_neutral_right. setoid_rewrite xif_xif_and.
     rewrite sum_collapse'. setoid_rewrite <- andb_assoc. rewrite sum_collapse'.  
       apply xif_compat; auto. rewrite 2id_num. rewrite match_pi1. 
-      rewrite bool_prop_iff. bool_connectors. num_prop. intuition. num_omega. apply (bounded_delta HB).
-      unfold s. rewrite <- lt_nat_spec. apply below_max_pi1. num_omega.
+      rewrite bool_prop_iff. bool_connectors. num_prop. intuition. num_lia. apply (bounded_delta HB).
+      unfold s. rewrite <- lt_nat_spec. apply below_max_pi1. num_lia.
       apply -> lt_nat_spec. apply (bounded_delta HB).
 
    mx_intros i j Hi Hj. Transparent dot. simpl. fold_regex. Opaque dot. 
     setoid_rewrite dot_xif_zero. setoid_rewrite dot_neutral_left.
     setoid_rewrite <- andb_assoc. rewrite sum_collapse'. apply xif_compat; auto.
     rewrite id_num. rewrite bool_prop_iff. bool_connectors. num_prop. StateSetProps.mem_prop.
-    rewrite and_neutral_left by num_omega.
+    rewrite and_neutral_left by num_lia.
     apply StateSetProps.Props.fold_rec_nodep. 
      (* BUG d'induction *)
      (* induction (finaux B) using StateSetProps.set_induction_above. *)
@@ -202,7 +202,7 @@ Proof.
      repeat intro. StateSetProps.set_iff. tauto.
      intro. rewrite H1. StateSetProps.set_iff. tauto.
     intros x a _. StateSetProps.set_iff. intuition psubst. discriminate.
-    apply -> lt_nat_spec. apply below_max_pi1. num_omega.
+    apply -> lt_nat_spec. apply below_max_pi1. num_lia.
     Opaque NumSet.add.
 Qed.
 

--- a/theories/DKA_StateSetSets.v
+++ b/theories/DKA_StateSetSets.v
@@ -76,7 +76,7 @@ Proof.
   apply StateSetProps.Props.empty_is_empty_1.
   rewrite StateSetProps.Props.elements_Empty.
   remember (StateSet.elements p) as l. destruct l as [|i l]. trivial.
-  specialize (H i). apply apply in H. exfalso. clear - H. num_omega.
+  specialize (H i). apply apply in H. exfalso. clear - H. num_lia.
   rewrite StateSetProps.Facts.elements_iff. rewrite <- Heql. auto. 
 Qed.
 
@@ -114,7 +114,7 @@ Proof.
   replace (StateSetSet.cardinal t0) with (StateSetSet.cardinal t0').
   assert (IH1 := IHs t1). apply apply in IH1. 
   assert (IH0 := IHs t0'). apply apply in IH0. 
-  omega.
+  lia.
 
    subst t0' t0. clear t1 IH1 IH0. intros p Hp. 
    destruct (statesetset_map_in Hp) as [q Hq Hq']. revert Hq.
@@ -126,7 +126,7 @@ Proof.
     exfalso. revert Hx. clear. StateSetProps.setdec. 
    rewrite <- StateSetSetProps.mem_iff in Hq. 
    rewrite <- StateSetProps.mem_iff in Hq''. 
-   specialize (H q Hq x). apply apply in H. clear - H n. num_omega. StateSetProps.setdec.
+   specialize (H q Hq x). apply apply in H. clear - H n. num_lia. StateSetProps.setdec.
 
    subst t1. clear t0 t0' IH1. intro p. 
    rewrite StateSetSetProps.mem_iff.
@@ -134,7 +134,7 @@ Proof.
    case_eq (StateSetSet.mem p t). 2:(intros; discriminate). simpl. intros Hp Hp'. 
    intros x Hx. 
    destruct (eq_num_dec x s). subst. apply StateSet.mem_1 in Hx. rewrite Hx in Hp'. discriminate.
-   apply StateSetSet.mem_2 in Hp. pose (H' := H p Hp x Hx). num_omega.
+   apply StateSetSet.mem_2 in Hp. pose (H' := H p Hp x Hx). num_lia.
 
   subst t0' t0. clear t1.
   apply statesetset_map_cardinal. 
@@ -239,14 +239,14 @@ Lemma in_classes: forall t size x,
   StateSetSet.In x (classes size t) <-> exists2 y, y<size & StateSet.Equal x (DS.class_of t (state_of_nat y)).
 Proof.
   induction size; intros x; simpl; unfold add_classes; StateSetSetProps.set_iff.
-   intuition. destruct H. omega.
+   intuition. destruct H. lia.
    rewrite IHsize. clear IHsize.
    completer idtac.
-    symmetry in H. eauto with omega.
-    destruct H. eauto with omega.
+    symmetry in H. eauto with lia.
+    destruct H. eauto with lia.
     destruct H as [y Hy H]. destruct (eq_nat_dec y size). subst. 
      symmetry in H. auto.
-     right. exists y. omega. assumption. 
+     right. exists y. lia. assumption. 
 Qed.
 
 Lemma in_classes_empty_below: forall size x, 
@@ -255,7 +255,7 @@ Proof.
   intros size x H z. 
   rewrite in_classes in H. destruct H as [y Hy H].
   rewrite H. rewrite DSUtils.class_of_empty. StateSetProps.set_iff. 
-  intro. psubst. num_omega.
+  intro. psubst. num_lia.
 Qed.
 
 Lemma add_classes_empty: forall x a, 
@@ -278,9 +278,9 @@ Proof.
     clear. intros [H|H].
      eapply proj1 in H. apply apply in H. 2: rewrite StateSetProps.singleton_iff; trivial.
      revert H. StateSetProps.set_iff. intro. psubst. 
-     revert H. generalize (statesetelt_of_nat s). intro. num_omega.
+     revert H. generalize (statesetelt_of_nat s). intro. num_lia.
      apply in_classes_empty_below in H. specialize (H (Pos.succ (state_of_nat s))).
-     apply apply in H. num_omega. auto with set.
+     apply apply in H. num_lia. auto with set.
 Qed.
 
 Lemma classes_union_strict: forall `{DS.WF} size (x y: state), 
@@ -318,7 +318,7 @@ Lemma add_cardinal: forall s s' x,
   StateSetSet.cardinal (StateSetSet.add x s) < StateSetSet.cardinal s'.
 Proof.
   intros. destruct (StateSetSetProps.mem_spec x s) as [Hx|Hx]. 
-   rewrite StateSetSetProps.Props.add_cardinal_1; auto with omega.
+   rewrite StateSetSetProps.Props.add_cardinal_1; auto with lia.
    rewrite StateSetSetProps.Props.add_cardinal_2; auto.
 Qed.
 

--- a/theories/DKA_StateSetSets.v
+++ b/theories/DKA_StateSetSets.v
@@ -152,7 +152,7 @@ Proof.
   subst t0 t1. clear t0'. intro x. 
   setoid_rewrite StateSetSetProps.mem_iff. 
   do 2 rewrite StateSetSetProps.EqProps.filter_mem by solve_p1.
-  StateSetProps.mem_analyse; StateSetSetProps.mem_analyse; simpl; firstorder. 
+  StateSetProps.mem_analyse; StateSetSetProps.mem_analyse; simpl; firstorder congruence.
   
   subst t0 t1. clear t0'. intro x. 
   rewrite StateSetSetProps.EqProps.union_filter by trivial.

--- a/theories/DisjointSets.v
+++ b/theories/DisjointSets.v
@@ -459,9 +459,9 @@ Module PosDisjointSets <: DISJOINTSETS Positive.
       destruct (eq_num_dec i a). subst. 
       exists (S O). apply (DS _ _ b). map_iff. auto. apply DO.
       eauto.
-      omega.
+      lia.
       
-      destruct (IHD). exists (S x). eapply DS. 2 : eauto. map_iff. auto. omega.
+      destruct (IHD). exists (S x). eapply DS. 2 : eauto. map_iff. auto. lia.
     Qed.
     
     
@@ -469,7 +469,7 @@ Module PosDisjointSets <: DISJOINTSETS Positive.
       bounded (t [a>- b]) n.
     Proof.
       unfold bounded. intros. 
-      destruct (H x). destruct (D_update_ex _ _ H0). exists x1. auto. omega.
+      destruct (H x). destruct (D_update_ex _ _ H0). exists x1. auto. lia.
     Qed.
   End update.
   
@@ -486,21 +486,21 @@ Module PosDisjointSets <: DISJOINTSETS Positive.
       exists 1. apply (DS _ _  b).
       map_iff. auto. apply DO.
       map_iff; intros [H' | H']; subst. tauto_false. revert H'. eapply repr_inv_In. eauto.
-      omega. 
+      lia. 
       exists O. apply DO. map_iff.
       intros [H' | H']; subst; tauto_false. 
-      omega.
+      lia.
       destruct (eq_num_dec i a). subst.
       exists 1. apply (DS _ _  b).  map_iff. auto. apply DO. map_iff. 
       intros [H' | H']. subst. tauto_false. 
-      revert H'. eapply repr_inv_In. eauto. omega.   
-      destruct IHD. exists (S x). eapply DS.  2 : eauto. map_iff. auto. omega. 
+      revert H'. eapply repr_inv_In. eauto. lia.   
+      destruct IHD. exists (S x). eapply DS.  2 : eauto. map_iff. auto. lia. 
     Qed.  
     
     Lemma boundage_link : forall n, bounded t n ->  bounded (t [a>- b]) (S n).
     Proof.
       unfold bounded. intros. 
-      destruct (H x). destruct (D_link_ex _ _ H0). exists x1. auto. omega.
+      destruct (H x). destruct (D_link_ex _ _ H0). exists x1. auto. lia.
     Qed.
     
     Lemma repr_update_fwd :
@@ -617,13 +617,13 @@ Module PosDisjointSets <: DISJOINTSETS Positive.
       ).
     Proof.
       induction n; intros s t0 x y t' px Hxt Hx Hpx Hwf. 
-      omega_false.
+      lia_false.
       simpl in Hxt.
       find_analyse.
       case_eq (find_aux n x0 t0). intros p' t'' H'. rewrite H' in *. injection Hxt. intros. subst. clear Hxt. 
       
       destruct (D_succ _ _ _ _ H Hx).  subst . 
-      destruct (IHn s _ _ _ _ _ H' H0) as [Hy [[Hxy | Hxy] [Heq Hwf']] ] . omega. auto.
+      destruct (IHn s _ _ _ _ _ H' H0) as [Hy [[Hxy | Hxy] [Heq Hwf']] ] . lia. auto.
       subst. 
       assert (x <> y).
       eapply D_inv_n. 2:eauto. rewrite FEquiv_D; eauto. 

--- a/theories/Graph.v
+++ b/theories/Graph.v
@@ -110,12 +110,12 @@ Section leq.
 End leq.
 
 
-Hint Resolve @equal_refl : core.
-Hint Immediate @equal_sym : core.
+Hint Resolve equal_refl : core.
+Hint Immediate equal_sym : core.
  
 (* BUG : If we add [equal_refl_fit] as hints, they are added as eapply ...*)
 
-Hint Resolve @equal_refl_f1 @equal_refl_f2 : core.
+Hint Resolve equal_refl_f1 equal_refl_f2 : core.
 (* Hint Resolve @equal_refl_f1t @equal_refl_f2t *)
 
 Hint Extern 1 (equal ?A ?B (?f _ ?t) (?f _ ?t)) => apply @equal_refl_f1t : core.

--- a/theories/Graph.v
+++ b/theories/Graph.v
@@ -110,15 +110,15 @@ Section leq.
 End leq.
 
 
-Hint Resolve equal_refl : core.
-Hint Immediate equal_sym : core.
+Global Hint Resolve equal_refl : core.
+Global Hint Immediate equal_sym : core.
  
 (* BUG : If we add [equal_refl_fit] as hints, they are added as eapply ...*)
 
-Hint Resolve equal_refl_f1 equal_refl_f2 : core.
+Global Hint Resolve equal_refl_f1 equal_refl_f2 : core.
 (* Hint Resolve @equal_refl_f1t @equal_refl_f2t *)
 
-Hint Extern 1 (equal ?A ?B (?f _ ?t) (?f _ ?t)) => apply @equal_refl_f1t : core.
-Hint Extern 2 (equal ?A ?B (?f _ _ ?t) (?f _ _ ?t)) => apply @equal_refl_f2t : core.
+Global Hint Extern 1 (equal ?A ?B (?f _ ?t) (?f _ ?t)) => apply @equal_refl_f1t : core.
+Global Hint Extern 2 (equal ?A ?B (?f _ _ ?t) (?f _ _ ?t)) => apply @equal_refl_f2t : core.
 
-Hint Extern 3 (_ == _) => apply @xif_compat : core.
+Global Hint Extern 3 (_ == _) => apply @xif_compat : core.

--- a/theories/KleeneAlgebra.v
+++ b/theories/KleeneAlgebra.v
@@ -145,13 +145,13 @@ Section Props1.
 End Props1.
 
 (** hints *)
-Hint Extern 1 (equal _ _ _ _) => apply star_compat; instantiate: compat algebra.
-Hint Extern 0 (equal _ _ _ _) => apply star_make_left: algebra.
-Hint Extern 0 (equal _ _ _ _) => apply star_make_right: algebra.
-Hint Extern 0 (equal _ _ _ _) => apply star_one: algebra.
-Hint Extern 0 (equal _ _ _ _) => apply star_zero: algebra.
-Hint Extern 0 (leq _ _ _ _) => apply a_leq_star_a: algebra.
-Hint Extern 0 (leq _ _ _ _) => apply one_leq_star_a: algebra.
+Global Hint Extern 1 (equal _ _ _ _) => apply star_compat; instantiate: compat algebra.
+Global Hint Extern 0 (equal _ _ _ _) => apply star_make_left: algebra.
+Global Hint Extern 0 (equal _ _ _ _) => apply star_make_right: algebra.
+Global Hint Extern 0 (equal _ _ _ _) => apply star_one: algebra.
+Global Hint Extern 0 (equal _ _ _ _) => apply star_zero: algebra.
+Global Hint Extern 0 (leq _ _ _ _) => apply a_leq_star_a: algebra.
+Global Hint Extern 0 (leq _ _ _ _) => apply one_leq_star_a: algebra.
 
 Hint Rewrite @star_zero @star_one using ti_auto : simpl.
 Hint Rewrite @star_mon_is_one using ti_auto : simpl.
@@ -239,9 +239,9 @@ Section Props2.
    
 End Props2.
 
-Hint Extern 1 (leq _ _ _ _) => apply star_incr: compat algebra.
-Hint Extern 0 (equal _ _ _ _) => apply star_idem: algebra.
-Hint Extern 0 (equal _ _ _ _) => apply star_trans: algebra.
+Global Hint Extern 1 (leq _ _ _ _) => apply star_incr: compat algebra.
+Global Hint Extern 0 (equal _ _ _ _) => apply star_idem: algebra.
+Global Hint Extern 0 (equal _ _ _ _) => apply star_trans: algebra.
 
 
 (** more properties, by duality  *)

--- a/theories/Monoid.v
+++ b/theories/Monoid.v
@@ -18,12 +18,12 @@ Require Import BoolView.
 Set Implicit Arguments.
 Unset Strict Implicit.
 
-Hint Extern 0 (equal _ _ _ _) => first [ 
+Global Hint Extern 0 (equal _ _ _ _) => first [ 
     apply dot_assoc
   | apply dot_neutral_left
   | apply dot_neutral_right
 ]: algebra.
-Hint Extern 2 (equal _ _ _ _) => first [ 
+Global Hint Extern 2 (equal _ _ _ _) => first [ 
     apply dot_compat; instantiate
 ]: compat algebra.
 

--- a/theories/MxGraph.v
+++ b/theories/MxGraph.v
@@ -296,16 +296,16 @@ Section Props.
 
 End Props.
 
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub00_compat: compat algebra.
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub01_compat: compat algebra.
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub10_compat: compat algebra.
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub11_compat: compat algebra.
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_transpose_compat: compat algebra.
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_force_compat: compat algebra.
-Hint Extern 4 (mx_equal_ _ _ _ _ _) => apply mx_blocks_compat: compat algebra.
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_of_scal_compat: compat algebra.
-Hint Extern 1 (equal _ _ _ _) => apply mx_to_scal_compat: compat algebra.
-Hint Extern 5 (equal _ _ _ _) => apply mx_equal_compat : compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub00_compat: compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub01_compat: compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub10_compat: compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_sub11_compat: compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_transpose_compat: compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_force_compat: compat algebra.
+Global Hint Extern 4 (mx_equal_ _ _ _ _ _) => apply mx_blocks_compat: compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_of_scal_compat: compat algebra.
+Global Hint Extern 1 (equal _ _ _ _) => apply mx_to_scal_compat: compat algebra.
+Global Hint Extern 5 (equal _ _ _ _) => apply mx_equal_compat : compat algebra.
 
 (* Hint Resolve @equal_compat: compat algebra.  *)
   

--- a/theories/MxGraph.v
+++ b/theories/MxGraph.v
@@ -67,11 +67,11 @@ Notation "! M" := (get M) (at level 0) : A_scope.
 Notation "M == [ n , m ]  N" := (@equal (mx_Graph _) n m M N) (at level 80) : A_scope.
 
 Lemma plus_minus : forall m n, S (m+n)-n = S m.
-Proof. intros. omega. Qed.
+Proof. intros. lia. Qed.
 Global Opaque minus. 
 
 Lemma lt_n_1 n: ~ (S n<1)%nat.
-Proof. omega. Qed.
+Proof. lia. Qed.
 
 (** case analysis on block matrix acesses *)
 Ltac destruct_blocks :=
@@ -139,13 +139,13 @@ Section Props.
       Definition mx_sub11 := mx_sub x y n m M.
     End Def.
     Global Instance mx_sub00_compat: Proper (mx_equal (x+n) (y+m) ==> mx_equal x y) mx_sub00.
-    Proof. repeat intro. simpl. apply H; auto with omega. Qed.
+    Proof. repeat intro. simpl. apply H; auto with lia. Qed.
     Global Instance mx_sub01_compat: Proper (mx_equal (x+n) (y+m) ==> mx_equal x m) mx_sub01.
-    Proof. repeat intro. simpl. apply H; auto with omega. Qed.
+    Proof. repeat intro. simpl. apply H; auto with lia. Qed.
     Global Instance mx_sub10_compat: Proper (mx_equal (x+n) (y+m) ==> mx_equal n y) mx_sub10.
-    Proof. repeat intro. simpl. apply H; auto with omega. Qed.
+    Proof. repeat intro. simpl. apply H; auto with lia. Qed.
     Global Instance mx_sub11_compat: Proper (mx_equal (x+n) (y+m) ==> mx_equal n m) mx_sub11.
-    Proof. repeat intro. simpl. apply H; auto with omega. Qed.
+    Proof. repeat intro. simpl. apply H; auto with lia. Qed.
   End Subs.
 
 
@@ -178,7 +178,7 @@ Section Props.
       mx_equal (x+n) (y+m))
     mx_blocks.
     Proof. 
-      repeat intro. destruct_blocks; auto with omega.
+      repeat intro. destruct_blocks; auto with lia.
     Qed.
 
     Lemma mx_decompose_blocks :
@@ -190,7 +190,7 @@ Section Props.
           (mx_sub10 M)
           (mx_sub11 M).
     Proof.
-      simpl; intros. destruct_blocks; auto with omega. 
+      simpl; intros. destruct_blocks; auto with lia. 
     Qed.
   
     Section Proj.
@@ -199,22 +199,22 @@ Section Props.
   
       Lemma mx_block_00: mx_sub00 (mx_blocks a b c d) == a.
       Proof.
-        simpl. intros. destruct_blocks; reflexivity || omega_false.
+        simpl. intros. destruct_blocks; reflexivity || lia_false.
       Qed.
     
       Lemma mx_block_01: mx_sub01 (mx_blocks a b c d) == b.
       Proof.
-        simpl. intros. destruct_blocks; omega_false || auto with compat omega.
+        simpl. intros. destruct_blocks; lia_false || auto with compat lia.
       Qed.
     
       Lemma mx_block_10: mx_sub10 (mx_blocks a b c d) == c.
       Proof.
-        simpl. intros. destruct_blocks; omega_false || auto with compat omega.
+        simpl. intros. destruct_blocks; lia_false || auto with compat lia.
       Qed.
     
       Lemma mx_block_11: mx_sub11 (mx_blocks a b c d) == d.
       Proof.
-        simpl. intros. destruct_blocks; omega_false || auto with compat omega.
+        simpl. intros. destruct_blocks; lia_false || auto with compat lia.
       Qed.
 
     End Proj.
@@ -239,7 +239,7 @@ Section Props.
   Lemma mx_blocks_degenerate_00 (a: MX 1 1) b c (d: MX 0 0):
     (mx_blocks a b c d: MX 1 1) == a.
   Proof.
-    intros [|] [|] Hi Hj; try omega_false. reflexivity. 
+    intros [|] [|] Hi Hj; try lia_false. reflexivity. 
   Qed.
 
   Lemma mx_blocks_degenerate_11 n m (a: MX 0 0) b c (d: MX n m):

--- a/theories/MxKleeneAlgebra.v
+++ b/theories/MxKleeneAlgebra.v
@@ -126,7 +126,7 @@ Section PreDefs.
     do 2 intuition.
     apply mx_blocks_incr; 
       apply plus_destruct_leq; simpl Peano.plus in *; trivial;
-        repeat intro; omega_false.
+        repeat intro; lia_false.
   Qed. 
 
   Definition prop_star_destruct_left n f := 
@@ -227,7 +227,7 @@ Section PreDefs.
     do 2 intuition.
     apply mx_blocks_incr; 
       apply plus_destruct_leq; simpl Peano.plus in *; trivial;
-        repeat intro; omega_false.
+        repeat intro; lia_false.
   Qed. 
 
   Definition prop_star_destruct_right n f := 

--- a/theories/MxSemiLattice.v
+++ b/theories/MxSemiLattice.v
@@ -174,5 +174,5 @@ Section Props.
 
 End Props.
 
-Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_point_compat: compat algebra.
+Global Hint Extern 1 (mx_equal_ _ _ _ _ _) => apply mx_point_compat: compat algebra.
 

--- a/theories/MxSemiRing.v
+++ b/theories/MxSemiRing.v
@@ -205,7 +205,7 @@ Section Props2.
     rewrite (plus_comm m), sum_cut. 
     apply plus_compat.
     apply sum_compat; intros. 
-    destruct_blocks. reflexivity. omega_false.
+    destruct_blocks. reflexivity. lia_false.
     rewrite (plus_comm m), sum_shift. 
     apply sum_compat; intros.
     destruct_blocks. reflexivity.
@@ -213,7 +213,7 @@ Section Props2.
     rewrite (plus_comm m), sum_cut. 
     apply plus_compat.
     apply sum_compat; intros. 
-    destruct_blocks. reflexivity. omega_false.
+    destruct_blocks. reflexivity. lia_false.
     rewrite (plus_comm m), sum_shift. 
     apply sum_compat; intros.
     destruct_blocks. reflexivity.
@@ -221,7 +221,7 @@ Section Props2.
     rewrite (plus_comm m), sum_cut. 
     apply plus_compat.
     apply sum_compat; intros. 
-    destruct_blocks. reflexivity. omega_false.
+    destruct_blocks. reflexivity. lia_false.
     rewrite (plus_comm m), sum_shift. 
     apply sum_compat; intros.
     destruct_blocks. reflexivity.
@@ -229,7 +229,7 @@ Section Props2.
     rewrite (plus_comm m), sum_cut. 
     apply plus_compat.
     apply sum_compat; intros. 
-    destruct_blocks. reflexivity. omega_false.
+    destruct_blocks. reflexivity. lia_false.
     rewrite (plus_comm m), sum_shift. 
     apply sum_compat; intros.
     destruct_blocks. reflexivity.

--- a/theories/MxSemiRing.v
+++ b/theories/MxSemiRing.v
@@ -174,8 +174,8 @@ Infix "*'" := dot_scal_right (at level 40): A_scope.
 
 
 
-Hint Extern 2 (mx_equal_ _ _ _ _ _) => apply dot_scal_left_compat: compat algebra.
-Hint Extern 2 (mx_equal_ _ _ _ _ _) => apply dot_scal_right_compat: compat algebra.
+Global Hint Extern 2 (mx_equal_ _ _ _ _ _) => apply dot_scal_left_compat: compat algebra.
+Global Hint Extern 2 (mx_equal_ _ _ _ _ _) => apply dot_scal_right_compat: compat algebra.
 
 Section Props2.
 

--- a/theories/MyFMapProperties.v
+++ b/theories/MyFMapProperties.v
@@ -31,7 +31,7 @@ Module MyMapProps (X : FMapInterface.S).
      destruct H as [w ?]. exists w. auto with map. 
   Qed. 
 
-  Hint Resolve mapsto_in in_add_1 in_add_2 : map.
+  Global Hint Resolve mapsto_in in_add_1 in_add_2 : map.
 
   Inductive find_spec_ind A k s : option A -> Prop :=
   | find_spec_1 : forall x, MapsTo k x s -> find_spec_ind A k s (Some x)

--- a/theories/MyFSetProperties.v
+++ b/theories/MyFSetProperties.v
@@ -297,12 +297,13 @@ Module MySetProps (X : FSetInterface.S).
         rewrite <- (Hcompat _ _ H0) in H1. auto. 
         firstorder. 
         firstorder. 
-        firstorder. 
+        eauto using E.eq_refl.
     Qed.
 
     Lemma exists_empty :  exists_ f empty = false.
     Proof.
       assert (forall b, b = false <-> ~b=true). clear. intros [|]; firstorder.
+      congruence.
       rewrite H.  clear H. intro. 
       rewrite <- exists_iff in H. destruct H. setdec.
       apply Hcompat.

--- a/theories/MyFSetProperties.v
+++ b/theories/MyFSetProperties.v
@@ -110,7 +110,7 @@ Module MySetProps (X : FSetInterface.S).
     Qed.
     Next Obligation.
       assert (In x s). apply min_elt_1. auto. 
-      assert (forall x y, S x <= y -> x < y) by (intros; omega). apply H0. clear H0.       
+      assert (forall x y, S x <= y -> x < y) by (intros; lia). apply H0. clear H0.       
       rewrite EqProps.remove_cardinal_1. auto. 
       rewrite <-mem_iff. auto. 
     Qed.

--- a/theories/Numbers.v
+++ b/theories/Numbers.v
@@ -75,7 +75,7 @@ Module Type NUM.
   Axiom le_spec : forall n m, reflect (le n m) (leb n m).
   Axiom lt_spec : forall n m, reflect (lt n m) (ltb n m).
   Axiom eq_spec : forall n m, reflect (n = m)  (eqb n m).
-  Axiom compare_spec : forall n m, compare_spec eq lt n m (compare n m).
+  Axiom compare_spec : forall n m, BoolView.compare_spec eq lt n m (compare n m).
 
   (* specification of operations and predicates, w.r.t. nat *)
   Axiom S_nat_spec : forall n, nat_of_num (S n) = Datatypes.S (nat_of_num n).
@@ -372,7 +372,7 @@ Module Positive <: NUM.
     intro H'. apply ZC1 in H. assert (H'' := Pos.lt_trans _ _ _ H H'). refine (Pos.lt_irrefl _ H''). 
   Qed.
   Definition eq_spec := eq_pos_spec.
-  Lemma compare_spec : forall n m, compare_spec eq lt n m (compare n m). 
+  Lemma compare_spec : forall n m, BoolView.compare_spec eq lt n m (compare n m). 
   Proof. 
    intros.
    case_eq (compare n m); intro H;  constructor.

--- a/theories/Numbers.v
+++ b/theories/Numbers.v
@@ -499,7 +499,7 @@ Module Positive <: NUM.
             end); subst.
 
   (* and this hints to automatically prove some trivial facts, by reflexivity *)
-  Hint Extern 0 (Pos_as_OTA.compare _ _ = Eq) => apply Pos_as_OT.eq_refl : core.
+Global   Hint Extern 0 (Pos_as_OTA.compare _ _ = Eq) => apply Pos_as_OT.eq_refl : core.
 
   Lemma pcompare_prop: forall x y, Pos_as_OTA.compare x y = Eq <-> x = y. 
   Proof. intros. intuition; psubst; trivial. Qed. 

--- a/theories/Numbers.v
+++ b/theories/Numbers.v
@@ -14,9 +14,9 @@
     This interface is then instanciated with positive, and we are able
     to use positive maps in our development.
 
-    In [NUMUTILS] we define a tactic [num_omega] (and its couterparts
-    [num_omega_false]), that reflects equalities and inequalities from
-    [num] into [nat] and then calls [omega]. This tactic is implemented
+    In [NUMUTILS] we define a tactic [num_lia] (and its couterparts
+    [num_lia_false]), that reflects equalities and inequalities from
+    [num] into [nat] and then calls [lia]. This tactic is implemented
     with autorewrite libraires. 
     
     In [NUMUTILS], we also define tactics [num_analyse] and [num_prop]
@@ -209,14 +209,14 @@ Module NumUtils (N : NUM).
   Lemma leb_false : forall x y, leb x y = false <-> lt y x.
   Proof.
     intros. rewrite eq_not_negb. rewrite leb_true. 
-    rewrite le_nat_spec, lt_nat_spec. omega.
+    rewrite le_nat_spec, lt_nat_spec. lia.
   Qed.
   Lemma ltb_true : forall x y, ltb x y = true <-> lt x y. 
   Proof. intros. case lt_spec; intuition discriminate. Qed.
   Lemma ltb_false : forall x y, ltb x y = false <-> le y x.
   Proof.
     intros. rewrite eq_not_negb. rewrite ltb_true. 
-    rewrite le_nat_spec, lt_nat_spec. omega.
+    rewrite le_nat_spec, lt_nat_spec. lia.
   Qed.
   Lemma eqb_true : forall x y, eqb x y = true <-> x = y. 
   Proof. intros. case eq_spec; intuition discriminate. Qed.
@@ -244,7 +244,7 @@ Module NumUtils (N : NUM).
   Hint Rewrite  eqb_refl leb_refl id_nat id_num: bool_simpl.
 
 
-  (** * num_omega : injects every prop about nums into equivalent props about nats, then call omega*)
+  (** * num_lia : injects every prop about nums into equivalent props about nats, then call lia*)
   Lemma num_of_nat_comm : forall x y, x = num_of_nat y <-> nat_of_num x = y.
   Proof. 
     intros x y. split; [intros -> | intros <-]. 
@@ -259,19 +259,19 @@ Module NumUtils (N : NUM).
     rewrite id_num. reflexivity.
   Qed.
 
-  Hint Rewrite eq_nat_spec le_nat_spec lt_nat_spec S_nat_spec max_spec : num_omega.
-  Hint Rewrite nat_of_num_comm num_of_nat_comm : num_omega .
-  Hint Rewrite id_nat id_num : num_omega.
+  Hint Rewrite eq_nat_spec le_nat_spec lt_nat_spec S_nat_spec max_spec : num_lia.
+  Hint Rewrite nat_of_num_comm num_of_nat_comm : num_lia .
+  Hint Rewrite id_nat id_num : num_lia.
 
-  Ltac num_simpl := autorewrite with num_omega in *.
-  Ltac num_omega := num_simpl; intuition (subst; omega).
-  Ltac num_omega_false := exfalso; num_omega.
+  Ltac num_simpl := autorewrite with num_lia in *.
+  Ltac num_lia := num_simpl; intuition (subst; lia).
+  Ltac num_lia_false := exfalso; num_lia.
 
   Lemma eqb_eq_nat_bool: forall i j, 
     eqb i j = eq_nat_bool (nat_of_num i) (nat_of_num j). 
   Proof.
     intros. num_analyse. subst. bool_simpl. reflexivity.
-    symmetry. nat_prop. num_omega.
+    symmetry. nat_prop. num_lia.
   Qed.
 
   Lemma numseteqb_eq_nat_bool: forall i j, 
@@ -284,7 +284,7 @@ Module NumUtils (N : NUM).
   Hint Rewrite numseteqb_eq_nat_bool : bool_simpl.
 
   Lemma le_antisym: forall n m: num, n <= m -> m <= n -> n = m.
-  Proof. intros. num_omega. Qed. 
+  Proof. intros. num_lia. Qed. 
 
 End NumUtils.
 
@@ -348,7 +348,7 @@ Module Positive <: NUM.
     intros n.
     unfold nat_of_num. 
     assert (Hn : 0 < nat_of_P (num_of_nat n) ). apply lt_O_nat_of_P. 
-    assert (forall s n, 0 <s -> s = Datatypes.S n -> pred s = n). intros. omega.
+    assert (forall s n, 0 <s -> s = Datatypes.S n -> pred s = n). intros. lia.
     apply H. auto.  
     apply nat_of_P_o_P_of_succ_nat_eq_succ.
   Qed.
@@ -389,7 +389,7 @@ Module Positive <: NUM.
     intros n.
     unfold nat_of_num. rewrite nat_of_P_succ_morphism. simpl.
     assert (H := lt_O_nat_of_P n).
-    omega.
+    lia.
   Qed.
   Lemma le_nat_spec : forall n m, le n m <-> (nat_of_num n <= nat_of_num m)%nat. 
   Proof.
@@ -402,12 +402,12 @@ Module Positive <: NUM.
       apply H.
       apply nat_of_P_gt_Gt_compare_complement_morphism. auto. 
       unfold nat_of_num .
-      omega.
+      lia.
 
       intro H'.   
       apply nat_of_P_gt_Gt_compare_morphism in H'.
       unfold nat_of_num in H.
-      omega.
+      lia.
   Qed.
 
 
@@ -421,11 +421,11 @@ Module Positive <: NUM.
     assert (nat_of_P x < nat_of_P y).
     apply    nat_of_P_lt_Lt_compare_morphism. apply H.
     unfold nat_of_num.
-    omega.
+    lia.
     
     apply nat_of_P_lt_Lt_compare_complement_morphism.
     unfold nat_of_num in H.
-    omega.
+    lia.
   Qed.
 
   Lemma max_spec : forall n m, nat_of_num (max n m) = Max.max (nat_of_num n) (nat_of_num m).
@@ -468,9 +468,9 @@ Module Positive <: NUM.
   Lemma match_pi1: forall n, pimatch (pi1 n) = inr n. Proof. reflexivity. Qed.
     
   Lemma lt_pi0: forall n m, lt n m -> lt (pi0 n) (pi0 m).
-  Proof. intros n m. setoid_rewrite lt_nat_spec. unfold pi0, nat_of_num. rewrite 2 nat_of_P_xO. omega. Qed.
+  Proof. intros n m. setoid_rewrite lt_nat_spec. unfold pi0, nat_of_num. rewrite 2 nat_of_P_xO. lia. Qed.
   Lemma lt_pi1: forall n m, lt n m -> lt (pi1 n) (pi1 m).
-  Proof. intros n m. setoid_rewrite lt_nat_spec. unfold pi1, nat_of_num. rewrite 2 nat_of_P_xI. omega. Qed.
+  Proof. intros n m. setoid_rewrite lt_nat_spec. unfold pi1, nat_of_num. rewrite 2 nat_of_P_xI. lia. Qed.
 
   Module NumOTA := Pos_as_OTA.
 (*   Module NumSet' := FSetList.Make Pos_as_OT. Module NumSet := FSetHide NumSet'.  *)

--- a/theories/SemiLattice.v
+++ b/theories/SemiLattice.v
@@ -23,16 +23,16 @@ Lemma plus_neutral_right `{SemiLattice} A B: forall (x: X A B), x+0 == x.
 Proof. intros. rewrite plus_com; apply plus_neutral_left. Qed.
 
 (** Hints  *)
-Hint Extern 0 (leq _ _ _ _) => apply leq_refl : core.
+Global Hint Extern 0 (leq _ _ _ _) => apply leq_refl : core.
 
-Hint Extern 0 (equal _ _ _ _) => first [
+Global Hint Extern 0 (equal _ _ _ _) => first [
     apply plus_assoc
   | apply plus_com
   | apply plus_idem
   | apply plus_neutral_left
   | apply plus_neutral_right
 ]: algebra.
-Hint Extern 2 (equal _ _ _ _) => first [
+Global Hint Extern 2 (equal _ _ _ _) => first [
     apply plus_compat; instantiate
 ]: compat algebra.
 
@@ -462,20 +462,20 @@ endtests*)
 
 (** Hints  *)
 
-Hint Extern 1 (equal _ _ _ _) => first [ 
+Global Hint Extern 1 (equal _ _ _ _) => first [ 
     apply sum_compat
 ]: compat algebra.
 
-Hint Extern 0 (leq _ _ _ _) => first [ 
+Global Hint Extern 0 (leq _ _ _ _) => first [ 
   apply plus_destruct_leq
   | apply plus_make_left
   | apply plus_make_right
   | apply zero_inf
 ]: algebra.
-Hint Extern 1 (leq _ _ _ _) => first [ 
+Global Hint Extern 1 (leq _ _ _ _) => first [ 
     apply sum_incr
 ]: compat algebra.
-Hint Extern 2 (leq _ _ _ _) => first [ 
+Global Hint Extern 2 (leq _ _ _ _) => first [ 
     apply plus_incr
 ]: compat algebra.
 

--- a/theories/SemiLattice.v
+++ b/theories/SemiLattice.v
@@ -278,7 +278,7 @@ Section Props1.
     induction k'; simpl_sum_r.
      auto with algebra.
      rewrite IHk', plus_assoc.
-     auto with compat omega.
+     auto with compat lia.
   Qed.
   
   Lemma sum_cut_fun i k (f g: nat -> X A B):
@@ -295,17 +295,17 @@ Section Props1.
   Lemma sum_cut_nth n (f: nat -> X A B) i k:
     n<k -> sum i k f == sum i n f + f (i+n)%nat + sum (i+S n) (k-n-1) f.
   Proof.
-    intros; pattern k at 1; replace k with (S(k-n-1)+n)%nat by omega. 
+    intros; pattern k at 1; replace k with (S(k-n-1)+n)%nat by lia. 
     rewrite sum_cut.
     rewrite sum_enter_left, plus_assoc.
-    auto with compat omega.
+    auto with compat lia.
   Qed.
   Arguments sum_cut_nth : clear implicits.
   
   Lemma sum_shift d (f: nat -> X A B) i k:
     sum (i+d) k f == sum i k (fun u => f (u+d)%nat).
   Proof.
-    induction k; simpl_sum_r; auto with compat omega.
+    induction k; simpl_sum_r; auto with compat lia.
   Qed.
     
   Theorem sum_inversion (f: nat -> nat -> X A B) i i' k k':
@@ -322,7 +322,7 @@ Section Props1.
     (exists n, i<=n /\ n<i+k /\ x <== f n) -> x <== sum i k f.
   Proof. 
     intros [n [? [? E]]].
-    rewrite E, (sum_cut_nth (n-i))  by omega. 
+    rewrite E, (sum_cut_nth (n-i))  by lia. 
     replace (i+(n-i))%nat with n by auto with arith. 
     rewrite <- plus_make_left. apply plus_make_right.
   Qed.
@@ -337,30 +337,30 @@ Section Props1.
      auto using plus_destruct_leq.
      auto with arith.
      auto with arith.
-     intros; apply H; omega.  
+     intros; apply H; lia.  
   Qed.
     
   Lemma sum_plus : forall (f : nat -> X A B) i k a, 0 < k -> sum i k f + a == sum i k (fun n => f n + a).
   Proof.
     induction k; intros.
-      omega_false.
+      lia_false.
       simpl_sum_r.
       destruct (eq_nat_dec 0 k).
         subst. simpl_sum_r. auto with algebra.
         setoid_rewrite <- IHk. 
         setoid_rewrite switch at 2. rewrite <- !plus_assoc, plus_idem. reflexivity.
-        omega.
+        lia.
   Qed.
     
   Lemma sum_constant : forall i k (a : X A B),  0 < k -> sum i k (fun _ => a) == a.
   Proof. 
     induction k; intros. 
-      omega_false.
+      lia_false.
       simpl_sum_r.   
       destruct (eq_nat_dec 0 k).
         subst. simpl_sum_r. auto with algebra.
         setoid_rewrite IHk. trivial with algebra.
-        omega.
+        lia.
   Qed.
 
   Lemma sum_collapse n (f: nat -> X A B) i k:
@@ -369,7 +369,7 @@ Section Props1.
     sum i k f == f (i+n)%nat.
   Proof.
     intros Hn H.
-    rewrite (sum_cut_nth n), 2 sum_zero by  ( auto || intros; apply H ; omega).
+    rewrite (sum_cut_nth n), 2 sum_zero by  ( auto || intros; apply H ; lia).
     rewrite plus_neutral_left. apply plus_neutral_right.
   Qed.    
 

--- a/theories/SemiRing.v
+++ b/theories/SemiRing.v
@@ -322,18 +322,18 @@ endtests*)
   
       (* norm_aux *)
       destruct x; simpl in *.
-      rewrite dot_neutral_right; apply IHnorm_aux'; omega.
+      rewrite dot_neutral_right; apply IHnorm_aux'; lia.
       rewrite dot_ann_right, dot_ann_left, plus_com; apply plus_neutral_left.
-      rewrite <- IHnorm_aux, ! dot_assoc; trivial; simpl; omega.
-      rewrite <- 2 IHnorm_aux, dot_distr_right, dot_distr_left; trivial; omega.
-      rewrite <- IHnorm_aux'. rewrite VLst_add. reflexivity. omega.
+      rewrite <- IHnorm_aux, ! dot_assoc; trivial; simpl; lia.
+      rewrite <- 2 IHnorm_aux, dot_distr_right, dot_distr_left; trivial; lia.
+      rewrite <- IHnorm_aux'. rewrite VLst_add. reflexivity. lia.
   
       (* norm_aux' *)
       destruct y; simpl in *.
       rewrite dot_neutral_right. symmetry. apply VLSet_add. 
       rewrite dot_ann_right, plus_com; apply plus_neutral_left.
-      rewrite <- IHnorm_aux, dot_assoc; trivial; omega.
-      rewrite <- 2 IHnorm_aux', dot_distr_right; trivial; omega. 
+      rewrite <- IHnorm_aux, dot_assoc; trivial; lia.
+      rewrite <- 2 IHnorm_aux', dot_distr_right; trivial; lia. 
       rewrite VLSet_add. rewrite VLst_add. reflexivity.
     Qed.
   

--- a/theories/SemiRing.v
+++ b/theories/SemiRing.v
@@ -27,7 +27,7 @@ Set Implicit Arguments.
 Unset Strict Implicit.
 Set Asymmetric Patterns.
 
-Hint Extern 0 (equal _ _ _ _) => first [ 
+Global Hint Extern 0 (equal _ _ _ _) => first [ 
     apply dot_ann_left
   | apply dot_ann_right
   | apply dot_distr_left
@@ -890,7 +890,7 @@ Lemma sum_distr_left `{ISR: IdemSemiRing}: forall A B C (x: X B A) (f: nat -> X 
 Proof. exact (@sum_distr_right _ _ _ (@Dual.IdemSemiRing _ _ _ ISR)). Qed.
 
 
-Hint Extern 2 (leq _ _ _ _) => first [ 
+Global Hint Extern 2 (leq _ _ _ _) => first [ 
     apply dot_incr
 ]: compat algebra.
 

--- a/theories/StrictStarForm.v
+++ b/theories/StrictStarForm.v
@@ -66,7 +66,7 @@ Fixpoint contains_one e : bool :=
     | RegExp.one => true
     | RegExp.plus a b => contains_one a ||| contains_one b
     | RegExp.dot a b => contains_one a &&& contains_one b
-    | e => false
+    | _ => false
   end.
 
 Definition plus_but_one a b := 

--- a/theories/Utils_WF.v
+++ b/theories/Utils_WF.v
@@ -129,7 +129,7 @@ Section powerfix.
   Fixpoint power n := match n with O => 1 | S n => 2*power n end.
 
   Lemma power_positive: forall n, 0 < power n.
-  Proof. induction n; simpl; omega. Qed.
+  Proof. induction n; simpl; lia. Qed.
 
   (** Characterisation of [powerfix] with [linearfix] *)
   Section linear_carac.
@@ -176,7 +176,7 @@ Section powerfix.
        reflexivity.
        rewrite IHn. rewrite IHn.
        pose proof (power_positive n). 
-       replace (pred (power n + (power n + 0))) with (S (pred (power n) + pred (power n))) by omega.
+       replace (pred (power n + (power n + 0))) with (S (pred (power n) + pred (power n))) by lia.
        rewrite linearfix_plus.
        reflexivity.
     Qed.
@@ -187,7 +187,7 @@ Section powerfix.
     Proof.
       intros. unfold powerfix. setoid_rewrite powerfix'_linearfix.
       generalize (power_positive n). destruct (power n). 
-       intro. omega_false.
+       intro. lia_false.
        intro. reflexivity.
     Qed.
 


### PR DESCRIPTION
I fixed a number of incompatibilities with Coq 8.13. In a first pass I fixed small things I don't fully understand, then I fixed compatibility with these the warnings `fragile-hint-constr`, `omega-is-deprecated`, and `deprecated-hint-without-locality`.