### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/src/reify.ml
+++ b/src/reify.ml
@@ -45,7 +45,7 @@ let get_fun_5 d s = let v = get_const d s in fun x y z t u -> force_app v [|x;y;
 (* Coq constants *)
 module Coq = struct
   (* binary positive numbers *)
-  let positive_path = ["Coq" ; "Numbers"; "BinNums"]
+  let positive_path = ["Stdlib" ; "BinNums"; "BinNums"]
   let positive = get_const positive_path "positive"
   let xH = get_const positive_path "xH"
   let xI = get_fun_1 positive_path "xI"

--- a/theories/Common.v
+++ b/theories/Common.v
@@ -12,8 +12,8 @@
 From Coq Require Export Arith.
 From Coq Require Export Lia.
 From Coq Require Export BinNums BinPos PArith.Pnat.
-From Coq Require Export Program.Equality. 
-From Coq Require Export Setoid Morphisms. 
+From Coq.Program Require Export Equality.
+From Coq Require Export Setoid Morphisms.
 
 Set Implicit Arguments.
 


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
